### PR TITLE
[Falcons] Bug fixes for Composer, Cache, Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In the component's `composer.json`, specify:
 
 *   `type`, type of Magento 2 component.
 *   `extra/map`, list of files to move and their paths relative to the Magento root directory.
-*   `extra/chmod`, list of permissions of files that should be set.
+*   `extra/chmod`, list of permissions that should be set for files.
 
     **Note**:
     * `extra/map` is required only if your component needs to be moved to a location other than `<Magento root>/vendor`. Otherwise, omit this section.
@@ -175,7 +175,7 @@ The following example shows how you can set specific permissions for files.
 
 Example:
 
-```
+```json
 {
     "name": "magento/module-sample",
     "description": "N/A",
@@ -198,11 +198,11 @@ Example:
 }
 ```
 
-`mask` is bit mask for chmod command
+`mask` is a bit mask for chmod command
 
-`path` is path to file: `<magento_root>/<path>`
+`path` is a path to file: `<magento_root>/<path>`
 
-For example: `some_dir/file.jpg`
+For example: `<magento_root>/some_dir/file.jpg`
 
 # Notes
 - The extra->magento-root-dir option is no longer supported. It displays only to preseve backward compatibility.

--- a/README.md
+++ b/README.md
@@ -200,9 +200,7 @@ Example:
 
 `mask` is a bit mask for chmod command
 
-`path` is a path to file: `<magento_root>/<path>`
-
-For example: `<magento_root>/some_dir/file.jpg`
+`path` is a path to file relative to the Magento root folder
 
 # Notes
 - The extra->magento-root-dir option is no longer supported. It displays only to preseve backward compatibility.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ In the component's `composer.json`, specify:
 
 *   `type`, type of Magento 2 component.
 *   `extra/map`, list of files to move and their paths relative to the Magento root directory.
+*   `extra/chmod`, list of permissions of files that should be set.
 
-    **Note**: `extra/map` is required only if your component needs to be moved to a location other than `<Magento root>/vendor`. Otherwise, omit this section.
+    **Note**:
+    * `extra/map` is required only if your component needs to be moved to a location other than `<Magento root>/vendor`. Otherwise, omit this section.
+    * `extra/chmod` is required only if you need to set specific permissions for files.
+
 
 ## Supported Components
 The following list explains the use of `type` in `composer.json`.
@@ -164,6 +168,41 @@ You must run `composer install` to install dependencies for a new application or
 The Magneto Composer Installer uses the `copy` deployment strategy. It copies each file or directory from the `vendor` directory to its designated location based on the `extra/map` section in the component's `composer.json`.
 
 There are [other deployment strategies](https://github.com/magento/magento-composer-installer/blob/master/doc/Deploy.md) that could be used; however, we don't guarantee that any of them will work.
+
+## Usage `extra/chmod`
+
+The following example shows how you can set specific permissions for files.
+
+Example:
+
+```
+{
+    "name": "magento/module-sample",
+    "description": "N/A",
+    "require": {
+        ...
+    },
+    "type": "magento2-module",
+    "extra": {
+         "chmod": [
+            {
+                "mask": "0755",
+                "path": "bin/magento"
+            },
+            {
+                "mask": "0644",
+                "path": "some_dir/file.jpg"
+            }
+        ]
+    }
+}
+```
+
+`mask` is bit mask for chmod command
+
+`path` is path to file: `<magento_root>/<path>`
+
+For example: `some_dir/file.jpg`
 
 # Notes
 - The extra->magento-root-dir option is no longer supported. It displays only to preseve backward compatibility.

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -168,9 +168,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     private function setFilePermissions()
     {
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getPackages();
+        $message = 'Check "chmod" section in composer.json of %s package.';
 
         foreach ($packages as $package) {
-            $message = 'Check "chmod" section in composer.json of ' . $package->getName() . ' package.';
             $extra = $package->getExtra();
             if (!isset($extra['chmod']) || !is_array($extra['chmod'])) {
                 continue;
@@ -189,7 +189,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 } else {
                     $this->io->writeError([
                         'File doesn\'t exist: ' . $chmod['path'],
-                        $message
+                        sprintf($message, $package->getName())
                     ]);
                 }
             }
@@ -197,7 +197,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             if ($error) {
                 $this->io->writeError([
                     'Incorrect mask or file path.',
-                    $message
+                    sprintf($message, $package->getName())
                 ]);
             }
         }

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -157,7 +157,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->deployLibraries();
         $this->saveVendorDirPath($event->getComposer());
         $this->requestRegeneration();
-        $this->setFilesPermissions();
+        $this->setFilePermissions();
     }
 
     /**
@@ -165,7 +165,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      *
      * @return void
      */
-    private function setFilesPermissions()
+    private function setFilePermissions()
     {
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getPackages();
 


### PR DESCRIPTION
## Scope
### Bug - P1
- [MAGETWO-51598](https://jira.corp.magento.com/browse/MAGETWO-51598) bin/magento is installed without execute bit set
### Bamboo CI builds
- [x] [M2 L1 (unit, JS, BAT, WEB API)](https://bamboo.corp.magento.com/browse/M2-L1661/latest)
- [x] [M2 L2 (integration)](https://bamboo.corp.magento.com/browse/M2-L2647/latest)
- [x] [M2 L3 (integrity, static legacy, static)](https://bamboo.corp.magento.com/browse/M2-L3659/latest)
- [x] [M2 L4 (PHP 5.5)](https://bamboo.corp.magento.com/browse/M2-L459-1)
- [x] [Functional Acceptance Tests](https://bamboo.corp.magento.com/browse/M2-FAT686/latest)
- [x] [Functional Unstable Tests](https://bamboo.corp.magento.com/browse/M2-FUT295/latest)
- [x] [Performance Acceptance Test](https://bamboo.corp.magento.com/browse/M2-PAT623/latest)
- [x] [Sample Data Tests](https://bamboo.corp.magento.com/browse/M2-SDT563/latest)
- [x] [Semantic Version Checker](https://bamboo.corp.magento.com/browse/SVC-SVC472/latest)
- [x] [Client Side Performance]()
### Related Pull Requests

https://github.com/magento-falcons/magento2ce/pull/21
https://github.com/magento-falcons/magento2ee/pull/3
https://github.com/magento-falcons/magento2-infrastructure/pull/3
